### PR TITLE
Enhance: Cache logic changed

### DIFF
--- a/Core/Attributes/CacheableAttribute.cs
+++ b/Core/Attributes/CacheableAttribute.cs
@@ -85,16 +85,16 @@ public class Cacheable : Attribute, IAsyncActionFilter
 
                         view.RenderAsync(viewContext).GetAwaiter().GetResult();
 
-                        await _cacheClient.Set(key, writer.ToString(), _expire);
+                        await _cacheClient.Set(key, writer.ToString(), 0);
                     }
 
                     break;
                 }
                 case JsonResult jsonResult:
-                    await _cacheClient.Set(key, JsonConvert.SerializeObject(jsonResult.Value), _expire);
+                    await _cacheClient.Set(key, JsonConvert.SerializeObject(jsonResult.Value), 0);
                     break;
                 case ObjectResult objectResult:
-                    await _cacheClient.Set(key, JsonConvert.SerializeObject(objectResult.Value), _expire);
+                    await _cacheClient.Set(key, JsonConvert.SerializeObject(objectResult.Value), 0);
                     break;
             }
 

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
-        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="coverlet.collector" Version="1.2.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Core/CoreCacheExtension.cs
+++ b/Core/CoreCacheExtension.cs
@@ -1,13 +1,20 @@
 using Core.Driver;
 using Core.Entity;
+using Core.Enum;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Core;
 
 public static class CoreCacheExtension
 {
-    public static void AddCoreCache(this IServiceCollection services, uint buckets = 5)
+    public static void AddCoreCache(
+        this IServiceCollection services,
+        uint buckets = 5,
+        uint bucketMaxCapacity = 500000,
+        MaxMemoryPolicy maxMemoryPolicy = MaxMemoryPolicy.LRU,
+        int cleanUpPercentage = 10
+    )
     {
-        services.AddSingleton<ICacheClient>(new MemoryCache(buckets));
+        services.AddSingleton<ICacheClient>(new MemoryCache(buckets, bucketMaxCapacity, MaxMemoryPolicy.LRU, cleanUpPercentage));
     }
 }

--- a/Core/Driver/ICacheClient.cs
+++ b/Core/Driver/ICacheClient.cs
@@ -2,7 +2,7 @@ namespace Core.Driver;
 
 public interface ICacheClient
 {
-    ValueTask Set(string key, string value, long expire);
+    ValueTask Set(string key, string value, long expire = 0);
 
     ValueTask<string> Get(string key);
 

--- a/Core/Entity/CacheItem.cs
+++ b/Core/Entity/CacheItem.cs
@@ -3,5 +3,8 @@ namespace Core.Entity;
 public class CacheItem
 {
     public string Value { get; set; }
-    public DateTime? Timeout { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    public int Hits = 0;
 }

--- a/Core/Enum/MaxMemoryPolicy.cs
+++ b/Core/Enum/MaxMemoryPolicy.cs
@@ -1,0 +1,8 @@
+namespace Core.Enum;
+
+public enum MaxMemoryPolicy
+{
+    LRU, // Least Recently Used
+    RANDOM, // RANDOM
+    TTL // Time To Live
+}

--- a/CoreCache.ApiForTest/Controllers/WeatherForecastController.cs
+++ b/CoreCache.ApiForTest/Controllers/WeatherForecastController.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Core.Attributes;
 using CoreCache.ApiForTest.Entity;
 using CoreCache.ApiForTest.Utils;
@@ -13,7 +10,7 @@ namespace CoreCache.ApiForTest.Controllers;
 public class WeatherForecastController : ControllerBase
 {
     [Route("/"), HttpGet]
-    [Caching(typeof(Cacheable), "anything", "QueryId:{id}", TimeSpan.TicksPerSecond * 2)]
+    [Caching(typeof(Cacheable), "anything", "QueryId:{id}")]
     public IEnumerable<WeatherForecast> Get([FromQuery] string id)
     {
         return DataUtils.GetData();

--- a/IntegrationTests/ApiRequestCacheTests.cs
+++ b/IntegrationTests/ApiRequestCacheTests.cs
@@ -23,7 +23,6 @@ public class ApiRequestCacheTests : IClassFixture<WebApplicationFactory<Program>
     [Fact]
     public async void RequestCanCache()
     {
-        
         var resp1 = await _httpClient.GetAsync("/?id=1");
         var result1 = await resp1.Content.ReadAsStringAsync();
 
@@ -31,20 +30,6 @@ public class ApiRequestCacheTests : IClassFixture<WebApplicationFactory<Program>
         var result2 = await resp2.Content.ReadAsStringAsync();
 
         Assert.Equal(result1, result2);
-    }
-
-    [Fact]
-    public async void RequestCanCacheAndWillTimeout()
-    {
-        var resp1 = await _httpClient.GetAsync("/?id=2");
-        var result1 = await resp1.Content.ReadAsStringAsync();
-
-        await Task.Delay(TimeSpan.FromSeconds(2.5));
-        
-        var resp2 = await _httpClient.GetAsync("/?id=2");
-        var result2 = await resp2.Content.ReadAsStringAsync();
-
-        Assert.NotEqual(result1, result2);
     }
 
     [Fact]

--- a/IntegrationTests/MvcRequestCacheTests.cs
+++ b/IntegrationTests/MvcRequestCacheTests.cs
@@ -31,20 +31,6 @@ public class MvcRequestCacheTests : IClassFixture<WebApplicationFactory<Program>
 
         Assert.Equal(result1, result2);
     }
-    
-    [Fact]
-    public async void MvcRequestCanAutoEvict()
-    {
-        var resp1 = await _httpClient.GetAsync("/home/index?id=2");
-        var result1 = await resp1.Content.ReadAsStringAsync();
-
-        await Task.Run(() => Thread.Sleep(TimeSpan.FromSeconds(2.5)));
-
-        var resp2 = await _httpClient.GetAsync("/home/index?id=2");
-        var result2 = await resp2.Content.ReadAsStringAsync();
-
-        Assert.NotEqual(result1, result2);
-    }
 
     [Fact]
     public async void MvcRequestCanTriggerEvict()

--- a/README.md
+++ b/README.md
@@ -9,17 +9,27 @@
 
 * Easy use of caching with dotnet core
 * Fast, concurrent, evicting in-memory cache written to keep big number of entries without impact on performance.
-* The cache consists of many buckets, each with its own lock. This helps scaling the performance on multi-core CPUs, since multiple CPUs may concurrently access distinct buckets.
+* The cache consists of many buckets, each with its own lock. This helps scaling the performance on multi-core CPUs,
+  since multiple CPUs may concurrently access distinct buckets.
 
-## 🤟Install 
+## 🪣 About BigCache ( Multi Buckets )
+
+* Why`NetCoreCache` doesn't support cache expiration?
+* Because we don't need cache expiration in `NetCoreCache`. Cached entries inside `NetCoreCache` never expire. They are
+  automatically evicted on cache size overflow.
+* It is easy to implement cache expiration on top of `NetCoreCache` by caching values with marshaled deadlines and
+  verifying deadlines after reading these values from the cache.
+
+## 🤟Install
+
 ```
 PM     : Install-Package NetCoreCache
 Net CLI: dotnet add package NetCoreCache
 ```
 
-## 🚀Quick start
+## 🚀 Quick start
 
-```
+```c#
 // Program.cs
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCoreCache();
@@ -39,40 +49,16 @@ public class UserController : ControllerBase
 }
 ```
 
-## 🪣About BigCache ( Multi Buckets )
-```
-Services.AddCoreCache(5); // Default 5 buckets 
-Services.AddCoreCache(128); // Maximum number of 128 buckets
-```
-
-## Cache automatic eviction
-
-```
-// UserController.cs
-[ApiController]
-[Route("[controller]")]
-public class UserController : ControllerBase
-{
-    [Route("/"), HttpGet]
-    [Caching(typeof(Cacheable), "user", "{id}", TimeSpan.TicksPerSecond * 2)] // Cache expires after two seconds
-    public User Get([FromQuery] string id)
-    {
-        return DataUtils.GetData();
-    }
-}
-
-```
-
 ## Active cache eviction
 
-```
+```c#
 // UserController.cs
 [ApiController]
 [Route("[controller]")]
 public class UserController : ControllerBase
 {
     [Route("/"), HttpGet]
-    [Caching(typeof(Cacheable), "user", "{id}", TimeSpan.TicksPerHour * 2)] // Cache expires after two hours
+    [Caching(typeof(Cacheable), "user", "{id}")]
     public User Get([FromQuery] string id)
     {
         return DataUtils.GetData();
@@ -90,54 +76,85 @@ public class UserController : ControllerBase
 
 ```
 
-## ⭐️⭐️️Match both uses⭐️⭐️
+## 🎬 ️️Match both uses
 
+```c#
+// **** ‼️ If the cache is hit, 'Evicting' will only be executed once ‼️ ****
+
+[Route("/evict-and-cache"), HttpGet]
+[Caching(typeof(Cacheable), "anson", "QueryId:{id}")]
+[Evicting(typeof(CacheEvict), new[] { "anything" }, "QueryId:{id}")]
+public IEnumerable<WeatherForecast> Get([FromQuery] string id)
+{
+    return DataUtils.GetData();
+}
+
+
+
+// **** ‼️ Evicting will always execute ‼️ ****
+
+[Route("/evict-and-cache"), HttpGet]
+[Evicting(typeof(CacheEvict), new[] { "anything" }, "QueryId:{id}")]
+[Caching(typeof(Cacheable), "anson", "QueryId:{id}")]
+public IEnumerable<WeatherForecast> Get([FromQuery] string id)
+{
+    return DataUtils.GetData();
+}
 ```
-    **** ‼️ If the cache is hit, 'Evicting' will only be executed once ‼️ ****
-    
-    [Route("/evict-and-cache"), HttpGet]
-    [Caching(typeof(Cacheable), "anson", "QueryId:{id}")]
-    [Evicting(typeof(CacheEvict), new[] { "anything" }, "QueryId:{id}")]
-    public IEnumerable<WeatherForecast> Get([FromQuery] string id)
-    {
-        return DataUtils.GetData();
-    }
-    
-    
-    
-    **** ‼️ Evicting will always execute ‼️ ****
-    
-    [Route("/evict-and-cache"), HttpGet]
-    [Evicting(typeof(CacheEvict), new[] { "anything" }, "QueryId:{id}")]
-    [Caching(typeof(Cacheable), "anson", "QueryId:{id}")]
-    public IEnumerable<WeatherForecast> Get([FromQuery] string id)
-    {
-        return DataUtils.GetData();
-    }
+
+
+## 🎃 Parameter Description
+
+```c#
+public static void AddCoreCache(
+    this IServiceCollection services,
+    uint buckets = 5,                 
+    uint bucketMaxCapacity = 500000,
+    MaxMemoryPolicy maxMemoryPolicy = MaxMemoryPolicy.LRU,
+    int cleanUpPercentage = 10
+)
+{
+   services.AddSingleton<ICacheClient>(new MemoryCache(buckets, bucketMaxCapacity, MaxMemoryPolicy.LRU, cleanUpPercentage));
+}
 ```
+
+|                          Parameter                           | Type |       Default       | Require | Explain                                                                  |
+|:------------------------------------------------------------:|:----:|:-------------------:|:-------:|--------------------------------------------------------------------------|
+|                          `buckets`                           | uint |          5          |  false  | The number of containers to store the cache, up to 128                   |
+|                     `bucketMaxCapacity`                      | uint |       500000        |  false  | The capacity of each barrel, it is recommended that 500,000 ~ 1,000,000  |
+|                      `maxMemoryPolicy`                       | MaxMemoryPolicy | MaxMemoryPolicy.LRU |  false  | LRU = Least Recently Used , TTL = Time To Live, Or RANDOM                |
+|                     `cleanUpPercentage`                      | int |         10          |  false  | After the capacity is removed, the percentage deleted                    |  
 
 ## Variable explanation
 
-```
+```js
 // foo:bar:1 -> "item1"
 {
-   "foo": {
-      "bar": [
-         "item1",
-         "qux"
-     ]
-   }
+    "foo"
+:
+    {
+        "bar"
+    :
+        [
+            "item1",
+            "qux"
+        ]
+    }
 }
 
 // foo:bar:0:url -> "test.weather.com"
 {
-   "foo": {
-      "bar": [
-         {
-            "url": "test.weather.com",
-            "key": "DEV1234567"
-         }
-     ]
-   }
+    "foo"
+:
+    {
+        "bar"
+    :
+        [
+            {
+                "url": "test.weather.com",
+                "key": "DEV1234567"
+            }
+        ]
+    }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
   since multiple CPUs may concurrently access distinct buckets.
 
 ## 🪣 About BigCache ( Multi Buckets )
-
 * Why`NetCoreCache` doesn't support cache expiration?
 * Because we don't need cache expiration in `NetCoreCache`. Cached entries inside `NetCoreCache` never expire. They are
   automatically evicted on cache size overflow.


### PR DESCRIPTION
## 🪣 About BigCache ( Multi Buckets )
* Why`NetCoreCache` doesn't support cache expiration?
* Because we don't need cache expiration in `NetCoreCache`. Cached entries inside `NetCoreCache` never expire. They are
  automatically evicted on cache size overflow.
* It is easy to implement cache expiration on top of `NetCoreCache` by caching values with marshaled deadlines and
  verifying deadlines after reading these values from the cache.